### PR TITLE
feat: improve document chunk splitting

### DIFF
--- a/ia_provider/importer.py
+++ b/ia_provider/importer.py
@@ -177,7 +177,31 @@ def decouper_document_en_chunks(
     chunk_courant: List[Dict[str, Any]] = []
 
     for bloc in corps:
-        # On tente de couper sur les titres de niveau 1 pour conserver le contexte
+        # RÈGLE 1 : Si le chunk courant atteint le seuil, on le coupe de force.
+        if len(chunk_courant) >= seuil_blocs:
+            # RÈGLE 3 : Avant de couper, on vérifie s'il y a un titre orphelin.
+            if chunk_courant and chunk_courant[-1].get("type", "").startswith("heading"):
+                titre_orphelin = chunk_courant.pop()
+                nouveau_chunk_structure = {
+                    "header": document_structure.get("header", []),
+                    "body": chunk_courant,
+                    "footer": document_structure.get("footer", []),
+                }
+                chunks.append(nouveau_chunk_structure)
+
+                # Le nouveau chunk commence avec le titre qui était orphelin
+                chunk_courant = [titre_orphelin, bloc]
+                continue
+            else:
+                nouveau_chunk_structure = {
+                    "header": document_structure.get("header", []),
+                    "body": chunk_courant,
+                    "footer": document_structure.get("footer", []),
+                }
+                chunks.append(nouveau_chunk_structure)
+                chunk_courant = []
+
+        # Découpage sémantique sur les titres de chapitre
         if bloc.get("type") == "heading_1" and chunk_courant:
             nouveau_chunk_structure = {
                 "header": document_structure.get("header", []),


### PR DESCRIPTION
## Summary
- enforce chunk size threshold and handle orphan headings during document splitting
- maintain semantic splits on level-1 headings

## Testing
- `pytest`
- `python -m py_compile ia_provider/importer.py`


------
https://chatgpt.com/codex/tasks/task_b_68aee727fd94832b8dfb436b33caa1c0