### PR TITLE
Increase Anthropic token limit and adjust chunk size

### DIFF
--- a/ia_provider/anthropic.py
+++ b/ia_provider/anthropic.py
@@ -58,7 +58,7 @@ class AnthropicProvider(AnthropicBatchMixin, BaseProvider):
         
         # Anthropic requiert max_tokens
         if 'max_tokens' not in params:
-            params['max_tokens'] = 1000
+            params['max_tokens'] = 64000
         
         # Gestion de stop_sequences vs stop
         if 'stop' in params:

--- a/ia_provider/importer.py
+++ b/ia_provider/importer.py
@@ -153,7 +153,7 @@ def analyser_document(
 
 def decouper_document_en_chunks(
     document_structure: Dict[str, List[Dict[str, Any]]],
-    seuil_blocs: int = 200,
+    seuil_blocs: int = 150,
 ) -> List[Dict[str, List[Dict[str, Any]]]]:
     """Découpe une structure de document en plusieurs chunks si elle dépasse un seuil.
 


### PR DESCRIPTION
## Summary
- reduce importer chunk threshold to minimize size of input blocks
- set Anthropic max_tokens default to 64000 for full-length responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af5964b30c832b87cf568f1d97407f